### PR TITLE
update meta variable definitions to es6

### DIFF
--- a/opmltojs.js
+++ b/opmltojs.js
@@ -1,4 +1,4 @@
-var myProductName = "opmltojs"; myVersion = "0.4.10";
+const myProductName = "opmltojs", myVersion = "0.4.11";
 
 /*  The MIT License (MIT)
 	Copyright (c) 2014-2021 Dave Winer


### PR DESCRIPTION
hey @scripting, this is required to import the opml package into a logseq plugin via parcel. this is also already how the opmlPackage defines its top vars - https://github.com/scripting/opmlPackage/blob/main/opmlpackage.js#L1.

here is the error in logseq I currently get when trying to import the `opml` package and call `opml.markdownToOutline`:
<img width="1041" alt="image" src="https://user-images.githubusercontent.com/1139703/163851084-28832111-f02a-4618-9e3b-0a750ec333f7.png">

I deduced it was this package and not `opmlPackage` because the line it is complaining about is `myVersion = "0.4.11"`, which tracks to this package.

I updated the minor version in this line, presumably there's somewhere else where you'd need to do that too before publishing?